### PR TITLE
fix build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,9 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   add_definitions(-DMACOS=1)
 endif()
 
-set(FAUP_INCLUDE_DIRS "${faup-project_SOURCE_DIR}/src/lib/include/")
+set(FAUP_INCLUDE_DIRS "${faup-project_SOURCE_DIR}/src/lib/include/" "${faup-project_BINARY_DIR}/src/lib/include")
 
-set(FAUP_LIBRARY "${faup-project_SOURCE_DIR}/src/lib/libfaupl.so")
+set(FAUP_LIBRARY "${faup-project_BINARY_DIR}/src/lib/libfaupl.so")
 if(WIN32)
 	set(FAUP_LIBRARY "${faup-project_SOURCE_DIR}/src/lib/${CMAKE_BUILD_TYPE}/faupl.lib")
 endif(WIN32)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(AFTER "include/")
+include_directories(AFTER "include/" ${FAUP_INCLUDE_DIRS})
 
 set(FAUP_LIB_SRC_FILES
 decode.c


### PR DESCRIPTION
Without the following patch, I am unable to build the project.
The first error is:
$ make
Scanning dependencies of target faup_static
[ 11%] Building C object src/lib/CMakeFiles/faup_static.dir/decode.c.o
In file included from /home/georges/Projects/faup/src/lib/decode.c:18:  
/home/georges/Projects/faup/src/lib/include/faup/faup.h:24:26: error: faup/version.h: No such file or directory
make[2]: **\* [src/lib/CMakeFiles/faup_static.dir/decode.c.o] Error 1  
make[1]: **\* [src/lib/CMakeFiles/faup_static.dir/all] Error 2  
make: **\* [all] Error 2

which is fixed by line41 of file CMakeLists.txt

The next error occurs when building the cli tool faup when linking to the library.
The cmake variable FAUP_LIBRARY is set to "${faup-project_SOURCE_DIR}/src/lib/libfaupl.so", while the library is actually located at:
"${faup-project_BINARY_DIR}/src/lib/libfaupl.so"
