### PR TITLE
improve default performance

### DIFF
--- a/src/lib/options.c
+++ b/src/lib/options.c
@@ -54,8 +54,8 @@ void faup_options_defaults(faup_options_t *opts)
 	opts->sep_char = ',';
 	opts->input_source = FAUP_INPUT_SOURCE_ARGUMENT;
 	opts->current_line = 1;
-	opts->output = FAUP_OUTPUT_CSV;
-	opts->exec_modules = FAUP_MODULES_EXECPATH;
+	opts->output = FAUP_OUTPUT_NONE;
+	opts->exec_modules = FAUP_MODULES_NOEXEC;
 	opts->modules_argv = NULL;
 	opts->modules_argc = 0;
 	opts->number_of_chars_to_remove = 0;


### PR DESCRIPTION
I think FAUP_MODULES_EXECPATH and FAUP_OUTPUT_CSV options are not optimal for the default lib user, especially if he needs to init faup many times, as in the case of multithreaded programs. Just changing FAUP_MODULES_EXECPATH to FAUP_MODULES_NOEXEC gave me a 25x boost.
