### PR TITLE
Fixes bug in snapshot.c which errors out during build

### DIFF
--- a/src/lib/snapshot.c
+++ b/src/lib/snapshot.c
@@ -392,7 +392,7 @@ void faup_snapshot_output(faup_handler_t *fh, faup_snapshot_t *snapshot, FILE *f
 
   if (!snapshot) {
     fprintf(stderr, "Error reading snapshot. Stopping.\n");
-    return NULL;
+    return;
   }
   
   fprintf(fd, "{\n");


### PR DESCRIPTION
Line 395 seems to be returning a value in a void function, which clearly cannot be done. Here is the error:

```
faup/src/lib/snapshot.c:395:5: error: void function 'faup_snapshot_output' should not return
      a value [-Wreturn-type]
    return NULL;
    ^      ~~~~
```

This PR should fix it.