### PR TITLE
Allow reloading of Mozilla TLD list on demand

### DIFF
--- a/src/lib/faup.c
+++ b/src/lib/faup.c
@@ -44,6 +44,16 @@ faup_handler_t *faup_init(faup_options_t *options)
 	return fh;
 }
 
+// reload the TLD tree from the file on disk
+// useful if you have an external process fetching new copies from
+// https://publicsuffix.org/ and need faup to notice
+void faup_reload_tld_mozilla_list(faup_handler_t *fh)
+{
+
+	faup_tld_tree_free(fh->options->tld_tree, NULL, 0);
+	fh->options->tld_tree = faup_tld_tree_new();
+}
+
 char *faup_get_version(void)
 {
   return FAUP_VERSION;

--- a/src/lib/include/faup/faup.h
+++ b/src/lib/include/faup/faup.h
@@ -106,6 +106,8 @@ faup_handler_t *faup_init(faup_options_t *options);
 char *faup_get_version(void);
 void faup_terminate(faup_handler_t *fh);
 
+void faup_reload_tld_mozilla_list(faup_handler_t *fh);
+
 int32_t faup_get_scheme_pos(faup_handler_t *fh);
 uint32_t faup_get_scheme_size(faup_handler_t *fh);
 int32_t faup_get_credential_pos(faup_handler_t *fh);

--- a/src/lib/tld.c
+++ b/src/lib/tld.c
@@ -189,6 +189,7 @@ void faup_tld_array_destroy(void)
 {
     if (_tlds) {
 	utarray_free(_tlds);
+	_tlds = NULL;
     }
 }
 


### PR DESCRIPTION
Useful if you have an external process fetching a new list periodically.