### PR TITLE
Silence a warning about dirent->d_name

### DIFF
--- a/src/lib/snapshot-file.c
+++ b/src/lib/snapshot-file.c
@@ -80,7 +80,7 @@ faup_snapshot_t *faup_snapshot_read(char *dirpath)
   }
   snapshot = faup_snapshot_open(dirpath);
   while ((ent = readdir(dir)) != NULL) {
-    if ((ent->d_name) && (ent->d_name[0] != '.') && (ent->d_name[0] != '_')) {
+    if ((ent->d_name[0] != '\0') && (ent->d_name[0] != '.') && (ent->d_name[0] != '_')) {
       char *full_file_path;
       int retval;
       retval = asprintf(&full_file_path, "%s%c%s", dirpath, FAUP_OS_DIRSEP_C, ent->d_name);


### PR DESCRIPTION
d_name is an array so can never be NULL (assuming POSIX compliance). I assume
the test was supposed to make sure that it was safe to test d_name[0] but I
have converted it to make sure there are no entries without file names. Not
sure if that is possible on any OS...