### PR TITLE
Remove chardet library

### DIFF
--- a/src/lib/bindings/python/pyfaup/faup.py
+++ b/src/lib/bindings/python/pyfaup/faup.py
@@ -1,5 +1,4 @@
 import sys
-import chardet
 
 from .functions import *
 

--- a/src/lib/bindings/python/setup.py
+++ b/src/lib/bindings/python/setup.py
@@ -23,7 +23,7 @@ setup(
     url=about["__url__"],
     license=about["__license__"],
     packages = ["pyfaup"],
-    install_requires= ["chardet"],
+    install_requires= [],
     package_dir = {"pyfaup": "pyfaup/"},
     package_data = {'pyfaup': [
         'Linux/x86_64/libfaupl.so',


### PR DESCRIPTION
Hi @stricaud,

From my testing, the `chardet` library is not used within faup.  A search of `chardet` within the repo yielded only 2 results, so I removed all instances of it and it functionally still worked.  Side note, I also opened a ticket earlier this year about financially supporting the library (https://github.com/stricaud/faup/issues/116) - it's a great library!

1) Removed `chardet` in the 2 files.  Note when using `pip install` to pull from pypi, `chardet` is not even installed and must be manually installed.

2) Installed the library using `python setup.py install`

3) Ran the following commands to test it and it seemed fine

![image](https://user-images.githubusercontent.com/8660252/205294203-504390d1-8eac-419a-9c88-6fcc6589c98e.png)
