### PR TITLE
Fix miscalculation of domain size in faup_tld_tree_extract (issue #120)

### DIFF
--- a/src/lib/tld-tree.c
+++ b/src/lib/tld-tree.c
@@ -398,7 +398,7 @@ faup_tld_tree_extracted_t faup_tld_tree_extract(faup_handler_t *fh, TLDNode *tld
 
 	// We want to retrieve the size of the tld without the useless chars the come afterwards
 	// www.foo.siemens.om/tagada != www.foo.siemens.om
-	last_len = counter;
+	last_len = strlen(last);
 	last_len_just_for_host = last_len - (fh->faup.org_str_len - (fh->faup.features.host.pos + fh->faup.features.host.size));
 
 	counter = 0;


### PR DESCRIPTION
Following discussions on issue #120.

This is the fix we found to avoid invalid read by the `faup_tld_tree_tld_exists` function.

In early versions of the lib, a strlen was performed but was removed for efficiency reason.
I think that in the case of long sub-domains (relative to the TLD, it seems to be triggered when the sub domains is about twice the length of the TLD), the variable counter estimates badly the actual size of  the domain.

All tests pass (tested on Ubuntu 22.04 and HardenedBSD 12, 13 and 14) and I haven't encounter any other memory related issue (I tested it on about 3000 URLs) but I can't be certain that there are no side effect to this change with other convoluted domains.

I will be happy to discuss the change.