### PR TITLE
Improve pyfaup lib support

### DIFF
--- a/src/lib/bindings/python/pyfaup/__init__.py
+++ b/src/lib/bindings/python/pyfaup/__init__.py
@@ -30,5 +30,8 @@ if system == "Darwin":
                 LOAD_LIB=rundir + "/Darwin/x86_64/libfaupl.dylib"
 
 #print(LOAD_LIB)
-        
-bind.library = cdll.LoadLibrary(LOAD_LIB)
+
+try:
+        bind.library = cdll.LoadLibrary(LOAD_LIB)
+except OSError:
+        raise ImportError("Could not find faup system library, please install it with your package manager")

--- a/src/lib/bindings/python/pyfaup/__init__.py
+++ b/src/lib/bindings/python/pyfaup/__init__.py
@@ -19,7 +19,7 @@ if is_32bits:
 system = platform.system()
 arch = platform.machine()
 
-LOAD_LIB=""
+LOAD_LIB="libfaupl.so"
 
 if system == "Linux":
         LOAD_LIB=rundir + "/Linux/x86_64/libfaupl.so"

--- a/src/lib/bindings/python/pyfaup/__version__.py
+++ b/src/lib/bindings/python/pyfaup/__version__.py
@@ -2,7 +2,7 @@
 
 __description__ = "Python bindings for the faup library"
 __url__ = "https://www.github.com/stricaud/faup"
-__version__ = "1.2"
+__version__ = "1.5.1"
 __author__ = "Sebastien Tricaud"
 __author_email__ = "sebastien@honeynet.org"
 __license__ = "MIT"


### PR DESCRIPTION
### Added
- [PYFAUP] Allow for generic loading of 'libfaupl.so' library from python bindings (tested of FreeBSD)
- [PYFAUP] raise an ImportError when python module fails to load the C library